### PR TITLE
Add Instructions and Docker for Building from Source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ captures/
 
 # Keystore files
 *.jks
+
+# Android SDK
+/android-sdk.zip
+/android-studio

--- a/README.md
+++ b/README.md
@@ -19,3 +19,42 @@ Major contributions to Lens Launcher have been made by Rish Bhardwaj (@CreaRo)
 
 You can download Lens Launcher on Google Play:
 https://play.google.com/store/apps/details?id=nickrout.lenslauncher
+
+## Build from Source
+
+If you'd like to build from source, you may do so easily with [Docker][1], but
+if you are wanting to contribute it may be better to install the build tools on
+your machine.
+
+### Easy Way
+
+Building the APK is extremely easy using [`docker-compose`][2], all that is
+needed is to run the following inside the repo's directory:
+
+```bash
+docker-compose run --rm gradle
+```
+
+Then download the APK inside
+`lens-launcher/app/build/outputs/apk/app-release.apk` to your phone to install.
+
+### For Development
+
+1.  Install the latest Android SDK from [Android Studio][3] and accept the
+    licenses.
+2.  Install Java JDK 8 from [Oracle][4].
+3.  Run `keytool` and create a keystore following the command prompts.
+4.  Generate an APK with `gradlew` like below:
+
+    ```bash
+    gradlew assembleRelease \
+      -Pandroid.injected.signing.key.alias=$KEY_ALIAS \
+      -Pandroid.injected.signing.store.file=$KEY_STORE_PATH \
+      -Pandroid.injected.signing.store.password=$KEY_STORE_PASSWORD \
+      -Pandroid.injected.signing.key.password=$KEY_PASSWORD;
+    ```
+
+[1]: https://docs.docker.com/
+[2]: https://docs.docker.com/compose/install/
+[3]: https://developer.android.com/studio/index.html
+[4]: http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2'
+services:
+  gradle:
+    image: openjdk
+    working_dir: /app
+    environment:
+      - ANDROID_HOME=/app/android-studio
+    command: bash /app/docker-entrypoint.sh
+    volumes:
+      - '.:/app'
+      - '~/.gradle:/root/.gradle'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e;
+
+cd /app;
+
+# Ensure Android SDK is installed
+if [ ! -d /app/android-studio ]; then
+  echo "Android SDK directory not found.";
+
+  if [ ! -f /app/android-sdk.zip ]; then
+    echo "Android SDK zip file not found; beginning download.";
+
+    # Download the latest version of Android SDK
+    curl -L "$( \
+      curl -sL "https://developer.android.com/studio/index.html" \
+        | grep -Eoh "https?://.*?android-studio-ide.*?-linux\.zip" \
+    )" > /app/android-sdk.zip;
+
+  fi
+
+  # Unzips file to /app/android-studio
+  unzip /app/android-sdk.zip;
+fi
+
+# Sign Android SDK license
+if [ ! -d /app/android-studio/licenses/android-sdk-license ]; then
+  mkdir -p /app/android-studio/licenses;
+  echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" \
+    > /app/android-studio/licenses/android-sdk-license;
+fi
+
+# Generate self-signed cert
+keytool -genkey -noprompt \
+  -alias selfsigned \
+  -dname "CN=UNKNOWN, OU=UNKNOWN, O=UNKNOWN, L=UNKNOWN, S=UNKNOWN, C=UNKNOWN" \
+  -keystore /root/.keystore \
+  -storepass password \
+  -keypass password;
+
+# Create Lens Launcher APK
+/app/gradlew assembleRelease \
+  -Pandroid.injected.signing.key.alias=selfsigned \
+  -Pandroid.injected.signing.store.file=/root/.keystore \
+  -Pandroid.injected.signing.store.password=password \
+  -Pandroid.injected.signing.key.password=password;
+
+# Find the generated APK file in lens-launcher/app/build/outputs/apk/app-release.apk


### PR DESCRIPTION
Some people may want to just generate an APK with the latest changes instead of waiting for an app store release. This makes it easier for people to accomplish that. Plus, it adds a few instructions on how to get setup if people want to help contribute.