### PR TITLE
Another fix for the google calendar icon

### DIFF
--- a/app/src/main/java/nickrout/lenslauncher/util/BitmapUtil.java
+++ b/app/src/main/java/nickrout/lenslauncher/util/BitmapUtil.java
@@ -9,7 +9,6 @@ import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
-import android.support.v4.content.ContextCompat;
 
 /**
  * Created by nickrout on 2016/04/02.
@@ -89,7 +88,7 @@ public class BitmapUtil {
             Resources resources = packageManager.getResourcesForApplication(applicationInfo);
             Bitmap bitmap = resIdToBitmap(resources, resId);
             if (bitmap == null) {
-                final Drawable drawable = ContextCompat.getDrawable(context, resId);
+                Drawable drawable = packageManager.getApplicationIcon(packageName);
                 if (drawable != null) {
                     bitmap = drawableToBitmap(drawable);
                 }


### PR DESCRIPTION
After you install the system update for 7.1.1 on your google pixel, you'll see that the calendar icon isn't showing anymore, AGAIN.
The method `ContextCompat.getDrawable(Context, int)` was throwing a `Resources.NotFoundException`.
This PR fixes the issue by using `PackageManager.getApplicationIcon(String)` instead of `ContextCompat.getDrawable(Context, int)`