### PR TITLE
adjust transparent system bars in onResume so that the apps display correctly after opening a fullscreen app

### DIFF
--- a/app/src/main/java/nickrout/lenslauncher/ui/HomeActivity.java
+++ b/app/src/main/java/nickrout/lenslauncher/ui/HomeActivity.java
@@ -60,12 +60,6 @@ public class HomeActivity extends BaseActivity implements Observer {
     }
 
     @Override
-    public void onAttachedToWindow() {
-        super.onAttachedToWindow();
-        setupTransparentSystemBarsForLollipop();
-    }
-
-    @Override
     protected void onResume() {
         super.onResume();
         setupTransparentSystemBarsForLollipop();

--- a/app/src/main/java/nickrout/lenslauncher/ui/HomeActivity.java
+++ b/app/src/main/java/nickrout/lenslauncher/ui/HomeActivity.java
@@ -65,6 +65,12 @@ public class HomeActivity extends BaseActivity implements Observer {
         setupTransparentSystemBarsForLollipop();
     }
 
+    @Override
+    protected void onResume() {
+        super.onResume();
+        setupTransparentSystemBarsForLollipop();
+    }
+
     /**
      * Sets up transparent navigation and status bars in Lollipop.
      * This method is a no-op for other platform versions.


### PR DESCRIPTION
before this commit, the apps get drawn over the system bar sometimes.

Fixes issue #21 